### PR TITLE
Add memory check scripts.

### DIFF
--- a/memory/memory-check.sh
+++ b/memory/memory-check.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+TEST_DIR="build/bin"
+REPORT_DIR="reports/tests"
+
+# Replace '/' with '_' from test bin to create logfile.
+logfile=$(sed 's#/#_#g' <<<  $1).memcheck
+xmllogfile=$(sed 's#/#_#g' <<<  $1).xml
+
+# Run valgrind.
+valgrind --tool=memcheck --leak-check=full --track-origins=yes \
+         --num-callers=40 --error-exitcode=1 --xml=yes --xml-file=$REPORT_DIR/$xmllogfile --log-file=$REPORT_DIR/$logfile \
+         --verbose build/bin/mlpack_test -t $1

--- a/memory/parse-tests.py
+++ b/memory/parse-tests.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+# Get the test cases given the modified files, the CMakeLists file that
+# contains the test files and the path to the tests.
+#
+# parse_tests.py filenames.txt path/to/CMakeLists.txt path/to/tests
+
+import sys
+import re
+
+# Files that should not trigger the memory check.
+includeWhiteList = ["core.hpp"]
+cmakeFile = sys.argv[2]
+testFilePath = sys.argv[3]
+
+# Clean up the test file path.
+if not testFilePath.endswith('/'):
+  testFilePath = testFilePath + '/'
+
+# Read in the changed files line by line.
+with open(sys.argv[1], 'r') as file:
+  data = file.readlines()
+
+data = [x.strip() for x in data]
+if len(data) <= 0:
+  exit(0)
+
+# Clean the changed files: remove the path.
+changedFiles = []
+for x in data:
+  if x.find('/') != -1:
+    changedFiles.append(x.rsplit('/', 1)[-1])
+  else:
+    changedFiles.append(x)
+
+# Clean the changed files: usally we include the header file, so change the file
+# ending if only the implementation is changed.
+for x in range(0, len(changedFiles)):
+  file = changedFiles[x]
+
+  if "_impl" in file:
+    changedFiles.append(file.replace("_impl", ""))
+
+  if ".cpp" in file:
+    changedFiles.append(file.replace(".cpp", ".hpp"))
+
+changedFiles = list(set(changedFiles))
+
+with open(cmakeFile, 'r') as file:
+  data = file.readlines()
+data = [x.strip() for x in data]
+
+testSuites = []
+
+# Iterate through all test files and extract includes, test suite name and test
+# cases.
+for line in data:
+  start = line.find('.cpp')
+  if start != -1:
+    with open(testFilePath + line, 'r') as file:
+      testData = file.readlines()
+    testData = [x.strip() for x in testData]
+
+    testSuite = None;
+    includes = [];
+    testCases = [];
+    for testLine in testData:
+      testSuiteRegex = re.search('BOOST_AUTO_TEST_SUITE\((.*)\);', testLine)
+      testCaseRegex = re.search('BOOST_AUTO_TEST_CASE\((.*)\)', testLine)
+
+      includeRegex = re.search('#include <(.*)>', testLine)
+
+      if testSuiteRegex != None:
+        testSuite = testSuiteRegex.group(1)
+
+      if testCaseRegex != None:
+        testCases.append(testCaseRegex.group(1))
+
+      if includeRegex != None:
+
+        # Remove header files that are whitelisted.
+        skip = False;
+        for include in includeWhiteList:
+          if include in includeRegex.group(1):
+            skip = True;
+            break;
+
+        if not skip:
+          includes.append(includeRegex.group(1))
+
+    # Assemble the test cases that should be checked.
+    if testSuite != None:
+      for x in changedFiles:
+        if next((s for s in includes if x in s), None) != None:
+          for y in testCases:
+            testSuites.append(testSuite + "/" + y)
+
+          break;
+
+for x in list(set(testSuites)):
+  print(x)

--- a/memory/parse-tests.py
+++ b/memory/parse-tests.py
@@ -90,6 +90,7 @@ for line in data:
 
     # Assemble the test cases that should be checked.
     if testSuite != None:
+      includes.append(line)
       for x in changedFiles:
         if next((s for s in includes if x in s), None) != None:
           for y in testCases:

--- a/memory/runValgrindTestBins.sh
+++ b/memory/runValgrindTestBins.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Options
+WORKER=6
+REPORT_DIR="reports/tests"
+CHANGED_FILES="filenames.txt"
+CMAKE_FILE="./src/mlpack/tests/CMakeLists.txt"
+TEST_PATH="./src/mlpack/tests/"
+
+echo "Wipe out old reports."
+mkdir -p $REPORT_DIR
+rm -rf $REPORT_DIR/*
+
+echo "Finding test cases."
+./parse-tests.py $CHANGED_FILES $CMAKE_FILE $TEST_PATH > testbins.txt
+
+echo "Copy CSV files for tests to current working directory"
+cp ./src/mlpack/tests/data/* build/
+
+echo "Running all tests."
+cat testbins.txt | xargs -n 1 -P $WORKER -I % ./memory-check.sh %


### PR DESCRIPTION
Scripts to run Valgrind on the PR's. The script only runs Valgrind on the changed files, to do that, the script matches the changed files with the includes in tests in ``src/mlpack/tests``.

So if someone changed ``pca.hpp`` or ``pca_impl.hpp`` the script checks if any tests file includes one of this files and runs the test suite. It might be a good idea to build a dependency tree to improve the matching coverage, e.g. if someone changes ``adamax_update.hpp`` it will also trigger the ``Adam`` test suite, which is not the case since the test suite only includes ``adam.hpp`` which includes ``adamax_update.hpp``. But I think for now this is fine.