### PR TITLE
Unpack all compressed test data

### DIFF
--- a/runTestBins.sh
+++ b/runTestBins.sh
@@ -16,8 +16,13 @@ TEST_BINS=$(find $TEST_DIR -iname "*_test")
 echo "Copy CSV files for tests to current working directory"
 cp ./*/src/mlpack/tests/data/* .
 
-echo "Unpack mnist_first250_training_4s_and_9s.arm for sparse coding tests"
-tar -xvjpf mnist_first250_training_4s_and_9s.tar.bz2
+echo "Unpack compressed test data"
+TEST_DATA_ARCHIVE=$(find . -maxdepth 1 -iname "*bz2")
+for TEST_DATA in ${TEST_DATA_ARCHIVE}
+do
+    echo "Extract $TEST_DATA"
+    tar -xvjpf $TEST_DATA
+done
 
 echo "Running All Tests:"
 for ML_TEST in ${TEST_BINS}


### PR DESCRIPTION
Instead of extracting only specific archives we are extracting all, at least everything that is in the current test folder.