### PR TITLE
Use only one core (not sure if WORKER does anything).

### DIFF
--- a/memory/run-ensmallen-valgrind-tests.sh
+++ b/memory/run-ensmallen-valgrind-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Options
-WORKER=6
+WORKER=1
 REPORT_DIR="reports/tests"
 CMAKE_FILE="./src/ensmallen/tests/CMakeLists.txt"
 TEST_PATH="./src/ensmallen/tests/"

--- a/memory/run-mlpack-valgrind-tests.sh
+++ b/memory/run-mlpack-valgrind-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Options
-WORKER=6
+WORKER=1
 REPORT_DIR="reports/tests"
 CHANGED_FILES="filenames.txt"
 CMAKE_FILE="./src/mlpack/tests/CMakeLists.txt"


### PR DESCRIPTION
This should help make sure each job takes only one core.  However I'm not sure if the WORKER environment variable is ever used anywhere.  Still, it can't hurt. :)