### PR TITLE
memory - parse ensmallen tests

### DIFF
--- a/memory/parse-ensmallen-tests.py
+++ b/memory/parse-ensmallen-tests.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# Get the test cases given the modified files and the CMakeLists file that
+# contains the test files.
+#
+# parse_ensmallen_tests.py filenames.txt path/to/CMakeLists.txt
+
+import sys
+import os
+
+filenamesFile = sys.argv[1]
+cmakeFile = sys.argv[2]
+testPath = os.path.dirname(cmakeFile)
+
+# Read changed files.
+changedFiles = []
+with open(filenamesFile, 'r') as f:
+  changedFiles = f.readlines()
+
+# Clean the changed files: remove the path
+# and create trigger words.
+triggerWords = []
+for i, changedFile in enumerate(changedFiles):
+  name = os.path.basename(changedFile.strip())
+  name = os.path.splitext(name)[0]
+
+  name = name.lower()
+
+  name = name.replace('_impl', '')
+  if name not in triggerWords:
+    triggerWords.append(name)
+
+  name = name.replace('_', '')
+  if name not in triggerWords:
+    triggerWords.append(name)
+
+with open(cmakeFile, 'r') as f:
+  content = f.readlines()
+
+# Compile a list of test files.
+testFiles = []
+for line in content:
+  if '.cpp' in line and 'main.cpp' not in line:
+    testFiles.append(line.strip())
+
+# Iterate over all test files and check if a keyword exists in the file.
+testSuites = []
+for testFile in testFiles:
+  with open(testPath + '/' + testFile, 'r') as f:
+    content = f.read()
+
+  for word in triggerWords:
+    if word.lower() in content.lower():
+
+      # Extract the test suite name.
+      start = content.find('TEST_CASE(')
+      stop = content.find(')', start)
+
+      line = content[start:stop]
+      start = line.find('[') + 1
+      stop = line.find(']')
+
+      testSuite = line[start:stop]
+      if testSuite not in testSuites:
+        testSuites.append(testSuite)
+
+for testSuite in testSuites:
+  print('./ensmallen_tests "[' + testSuite + ']"')

--- a/memory/run-ensmallen-valgrind-tests.sh
+++ b/memory/run-ensmallen-valgrind-tests.sh
@@ -4,13 +4,13 @@
 WORKER=1
 REPORT_DIR="reports/tests"
 CMAKE_FILE="./src/ensmallen/tests/CMakeLists.txt"
-TEST_PATH="./src/ensmallen/tests/"
 
 echo "Wipe out old reports."
 mkdir -p $REPORT_DIR
 rm -rf $REPORT_DIR/*
 
-echo "Running all tests."
+echo "Finding test cases."
+./parse-ensmallen-tests.py $CHANGED_FILES $CMAKE_FILE > testbins.txt
 
 # Replace '/' with '_' from test bin to create logfile.
 logfile=ensmallen.memcheck
@@ -19,7 +19,5 @@ xmllogfile=ensmallen.xml
 # Copy data to the correct directory.
 cp -vr build/data/ data/
 
-# Run valgrind.
-valgrind --tool=memcheck --leak-check=full --track-origins=yes \
-         --num-callers=40 --error-exitcode=1 --xml=yes --xml-file=$REPORT_DIR/$xmllogfile --log-file=$REPORT_DIR/$logfile \
-         --verbose build/ensmallen_tests
+echo "Running all tests."
+cat testbins.txt | xargs -n 1 -P $WORKER -I % ./memory-check.sh %


### PR DESCRIPTION
Added a new script to parse the ensmallen tests, so given some changed files:

```
cat filenames.txt
path/path/adam_impl.hpp
nadam_update.hpp
iqn.hpp
sarah_impl.hpp
```

that we extract from the PR meta data we can call the added script like:

`python parse-tests.py filenames.txt tests/CMakeLists.txt`

the second argument is used to get all test files:

```
python parse-tests.py filenames.txt tests/CMakeLists.txt
./ensmallen_tests "[AdamTest]"
./ensmallen_tests "[CallbacksTest]"
./ensmallen_tests "[DemonAdamTest]"
./ensmallen_tests "[IQNTest]"
./ensmallen_tests "[LookaheadTest]"
./ensmallen_tests "[SARAHTest]"
```

What the script does is somewhat different from what we do in the mlpack script. In mlpack, we check if the test file includes one of the changed files, and depending on the result, we run the test suite. In ensmallen, we include `ensmallen.hpp` so we can't use the same strategy here.

So I checked if the filename or part of the changed file can be found in the test file. So let's say we changed `adam_update.hpp` which will be broken down into three trigger words: `adam, adamupdate, adam_update`, if any of the test files contain one of the trigger words it will be run.